### PR TITLE
Properly register units in container

### DIFF
--- a/src/Fabric/init.lua
+++ b/src/Fabric/init.lua
@@ -80,6 +80,10 @@ function Fabric:registerUnitsIn(container)
 					self._hotReloader:giveModule(object, unitDefinition)
 				end
 			end
+			
+			if next(object:GetChildren()) ~= nil then 
+				self:registerUnitsIn(object)
+			end
 		else
 			self:registerUnitsIn(object)
 		end


### PR DESCRIPTION
Fabric ignores the possibility that modulescripts can be containers. Use-cases where you want to nest units inside of a modulescript is not possible currently.